### PR TITLE
Fix oscap audit_rules_privileged_commands failure

### DIFF
--- a/config/hardening/ssg-supplemental.sh
+++ b/config/hardening/ssg-supplemental.sh
@@ -333,7 +333,7 @@ cat <<EOF > /etc/audit/rules.d/audit.rules
 EOF
 # Find all privileged commands and monitor them
 for fs in $(awk '($3 ~ /(ext[234])|(xfs)/) {print $2}' /proc/mounts) ; do
-	find $fs -xdev -type f \( -perm -4000 -o -perm -2000 \) | awk '{print "-a always,exit -F path=" $1 " -F perm=x -k privileged" }' >> /etc/audit/rules.d/audit.rules
+	find $fs -xdev -type f \( -perm -4000 -o -perm -2000 \) | awk '{print "-a always,exit -F path=" $1 " -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged" }' >> /etc/audit/rules.d/audit.rules
 done
 cat <<EOF >> /etc/audit/rules.d/audit.rules
 


### PR DESCRIPTION
I was experiencing an issue with oscap scans when using the auditd rules generated by `ssg-supplemental.sh`. This fixes that issue. 

Before:
![image](https://cloud.githubusercontent.com/assets/1253072/26462425/a6f1adb2-4178-11e7-89be-6461b1a37d69.png)

After:
![image](https://cloud.githubusercontent.com/assets/1253072/26462452/c26cafd8-4178-11e7-84f0-26038f66f36a.png)

Open to any feedback. 

Thanks,

Tim Birkett.